### PR TITLE
Missing events in Android App with nfc plugin

### DIFF
--- a/nfc.android.ts
+++ b/nfc.android.ts
@@ -247,6 +247,34 @@ class Activity extends android.app.Activity {
     this._callbacks.onCreate(this, savedInstanceState, super.onCreate);
   }
 
+  protected onSaveInstanceState(outState: android.os.Bundle): void {
+      this._callbacks.onSaveInstanceState(this, outState, super.onSaveInstanceState);
+  }
+
+  protected onStart(): void {
+      this._callbacks.onStart(this, super.onStart);
+  }
+
+  protected onStop(): void {
+      this._callbacks.onStop(this, super.onStop);
+  }
+
+  protected onDestroy(): void {
+      this._callbacks.onDestroy(this, super.onDestroy);
+  }
+
+  public onBackPressed(): void {
+      this._callbacks.onBackPressed(this, super.onBackPressed);
+  }
+
+  public onRequestPermissionsResult(requestCode: number, permissions: Array<String>, grantResults: Array<number>): void {
+      this._callbacks.onRequestPermissionsResult(this, requestCode, permissions, grantResults, undefined /*TODO: Enable if needed*/);
+  }
+
+  protected onActivityResult(requestCode: number, resultCode: number, data: android.content.Intent): void {
+      this._callbacks.onActivityResult(this, requestCode, resultCode, data, super.onActivityResult);
+  }
+
   onNewIntent(intent: android.content.Intent): void {
     super.onNewIntent(intent);
     application.android.foregroundActivity.setIntent(intent);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,9 +12,9 @@
       "node_modules/typescript/lib/lib.core.d.ts",
       "manual_typings/base.d.ts",
       "node_modules/tns-core-modules/tns-core-modules.d.ts",
-      "node_modules/tns-platform-declarations/tns-core-modules/android17.d.ts",
-      "node_modules/tns-platform-declarations/tns-core-modules/ios/ios.d.ts",
-      "node_modules/tns-platform-declarations/tns-core-modules/org.nativescript.widgets.d.ts",
+      "node_modules/tns-platform-declarations/android/android17.d.ts",
+      "node_modules/tns-platform-declarations/ios/ios.d.ts",
+      "node_modules/tns-platform-declarations/android/org.nativescript.widgets.d.ts",
       "nfc.common.ts",
       "nfc.android.ts", 
       "nfc.ios.ts"


### PR DESCRIPTION
In reference to issue #2, when the plugin was installed and the Activity class was extended the android app stopped recieveing a number of events that were being received beforehand (or at least the events were not able to be captured in the code).

Looking at the Nativescript Docs on [Extending the Activity](https://docs.nativescript.org/runtimes/android/advanced-topics/extend-application-activity#extending-activity), it looks like there are a number of events that should be defined oncluding _onBackPressed_.  When these were added the application started receiving the back event again and the navigation began behaving as normal.

Additionally the paths within the tns-platform-declerations module appear to have changed, so they have been updated too.