### PR TITLE
fix: prepare plugin for NativeScript 6.0.0 release

### DIFF
--- a/src/plugin-hooks/after-prepare.js
+++ b/src/plugin-hooks/after-prepare.js
@@ -1,8 +1,8 @@
 var fs = require('fs-promise');
 var path = require('path');
 
-module.exports = function (logger, platformsData, projectData, hookArgs) {
-	var platform = hookArgs.platform.toLowerCase();
+module.exports = function (logger, projectData, hookArgs) {
+	var platform = (hookArgs && (hookArgs.platform || (hookArgs.prepareData && hookArgs.prepareData.platform)) || '').toLowerCase();
 
 	if (platform == 'ios') {
 		var appResourcesDirectoryPath = projectData.appResourcesDirectoryPath;
@@ -14,7 +14,7 @@ module.exports = function (logger, platformsData, projectData, hookArgs) {
 		var fileToCopy = fs.existsSync(entitlementsFile) ? entitlementsFile : entitlementsFileAlt;
 		return fs.copy(fileToCopy, dest)
 			.then(function () {
-				logger.out('Copied `' + fileToCopy + '` to `' + dest + '`');
+				logger.info('Copied `' + fileToCopy + '` to `' + dest + '`');
 			});
 	}
 

--- a/src/plugin-hooks/before-prepare.js
+++ b/src/plugin-hooks/before-prepare.js
@@ -1,8 +1,8 @@
 var fs = require('fs-promise');
 var path = require('path');
 
-module.exports = function (logger, platformsData, projectData, hookArgs) {
-	var platform = hookArgs.platform.toLowerCase();
+module.exports = function (logger, projectData, hookArgs) {
+	var platform = (hookArgs && (hookArgs.platform || (hookArgs.prepareData && hookArgs.prepareData.platform)) || '').toLowerCase();
 
 	if (platform == 'ios') {
 		var appResourcesDirectoryPath = projectData.appResourcesDirectoryPath;


### PR DESCRIPTION
In NativeScript 6.0.0 there's a major refactoring in CLI that will require changes in most of the plugin hooks.
The major changes are the hookArgs injected by CLI for each hook - they are changed, so some of the properties used from them, should be taken from different property.
The other major change is the injected data - in the function used as hook, you can use any service registered in CLI's bootstrap and CLI will pass it to the hook.
Several of the services are now renamed or deleted, so hooks using them should be migrated. Such service is platformsData.
The last major change is that some logger methods are deleted (they've been deprecated).

The current PR makes the hooks of this plugin compatible with the both 6.0.0 and old releases of NativeScript.

> NOTE: I'm not sure the current hooks are actually required. NativeScript CLI has a logic to support app.entitlements files from both App_Resources and from plugins. During project preparation NativeScript CLI will check all app.entitlements files and merge them in a single file inside `platforms/ios...`. However, the current after-prepare hook of this plugin will overwrite the file with the content of `App_Resources/iOS/app.entitlements` file. This will break plugins which have their own app.entitlements files, as they will not be included in the native iOS project.