### PR TITLE
Using immutable flag for intent

### DIFF
--- a/src/nfc.android.ts
+++ b/src/nfc.android.ts
@@ -470,7 +470,7 @@ export class Nfc implements NfcApi {
           activity,
           0,
           this.intent,
-          0
+          33554432 // Constant for FLAG_IMMUTABLE
         );
 
         // The adapter must be started with the foreground activity.


### PR DESCRIPTION
Solves error message on android using flag mentioned in comment https://github.com/EddyVerbruggen/nativescript-nfc/issues/78#issuecomment-1456332372

```
JS: [Vue warn]: Error in mounted hook: "Error: java.lang.IllegalArgumentException: org.nativescript.Fox: Targeting S+ (version 31 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent.
  JS: Strongly consider using FLAG_IMMUTABLE, only use FLAG_MUTABLE if some functionality depends on the PendingIntent being mutable, e.g. if it needs to be used with inline replies or bubbles."
  JS:
  JS: found in
  JS:
  JS: ---> <Nfc> at app/components/Nfc.vue
  JS:        <Frame>
  JS:          <TabViewItem>
  JS:            <TabView>
  JS:              <App> at app/components/App.vue
  JS:                <Root>
  JS: LOG [PHOTO Camera permission success]
  JS: vuex settings set cam true boolean
  JS: GPS getLocation: authorized true
  System.err: An uncaught Exception occurred on "main" thread.
  System.err: Unable to start activity ComponentInfo{org.nativescript.Fox/com.tns.NativeScriptActivity}: com.tns.NativeScriptException: Calling js method onCreate failed
  System.err: Error: java.lang.IllegalArgumentException: org.nativescript.Fox: Targeting S+ (version 31 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent.
  System.err: Strongly consider using FLAG_IMMUTABLE, only use FLAG_MUTABLE if some functionality depends on the PendingIntent being mutable, e.g. if it needs to be used with inline replies or bubbles.
  System.err:
  System.err: StackTrace:
  System.err: java.lang.RuntimeException: Unable to start activity ComponentInfo{org.nativescript.Fox/com.tns.NativeScriptActivity}: com.tns.NativeScriptException: Calling js method onCreate failed
  System.err: Error: java.lang.IllegalArgumentException: org.nativescript.Fox: Targeting S+ (version 31 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent.
  System.err: Strongly consider using FLAG_IMMUTABLE, only use FLAG_MUTABLE if some functionality depends on the PendingIntent being mutable, e.g. if it needs to be used with inline replies or bubbles.
  System.err: 	at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:4111)
  System.err: 	at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:4277)
  System.err: 	at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:103)
  System.err: 	at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:135)
  System.err: 	at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:95)
  System.err: 	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2443)
  System.err: 	at android.os.Handler.dispatchMessage(Handler.java:106)
  System.err: 	at android.os.Looper.loopOnce(Looper.java:226)
  System.err: 	at android.os.Looper.loop(Looper.java:313)
  System.err: 	at android.app.ActivityThread.main(ActivityThread.java:8751)
  System.err: 	at java.lang.reflect.Method.invoke(Native Method)
  System.err: 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:571)
  System.err: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1135)
  System.err: Caused by: com.tns.NativeScriptException: Calling js method onCreate failed
```